### PR TITLE
Reduce the number of frame copies to improve performance

### DIFF
--- a/glsl/quad.frag
+++ b/glsl/quad.frag
@@ -44,31 +44,29 @@ void main() {
                 - compute_erf7(inverse_blur * distance));
         out_color = quad.color;
         out_color.w *= alpha;
-    } else {
-        if (distance <= 0.0) {
-            if (quad.blur < 0.0) {
-                // Internal box blur sampled from background
-                // Blur the quad background by sampling surrounding pixels
-                // and averaging them using a dumb box blur.
-                vec4 blurred_background = vec4(0.0);
-                int blur = int(-quad.blur);
-                int kernel_radius = abs(blur) - 1;
-                float weight = 1.0 / pow((abs(kernel_radius) * 2 + 1), 2);
-                for (int y=-kernel_radius;y<=kernel_radius;y++) {
-                    for (int x=-kernel_radius;x<=kernel_radius;x++) {
-                        vec2 offset = vec2(x, y);
-                        vec2 sample_pos = (gl_FragCoord.xy + offset) / constants.surface_size;
-                        vec4 sampled = texture(sampler2D(surface, texture_sampler), sample_pos);
-                        blurred_background += sampled * weight;
-                    }
+    } else if (distance <= 0.0) {
+        if (quad.blur < 0.0) {
+            // Internal box blur sampled from background
+            // Blur the quad background by sampling surrounding pixels
+            // and averaging them using a dumb box blur.
+            vec4 blurred_background = vec4(0.0);
+            int blur = int(-quad.blur);
+            int kernel_radius = abs(blur) - 1;
+            float weight = 1.0 / pow((abs(kernel_radius) * 2 + 1), 2);
+            for (int y=-kernel_radius;y<=kernel_radius;y++) {
+                for (int x=-kernel_radius;x<=kernel_radius;x++) {
+                    vec2 offset = vec2(x, y);
+                    vec2 sample_pos = (gl_FragCoord.xy + offset) / constants.surface_size;
+                    vec4 sampled = texture(sampler2D(surface, texture_sampler), sample_pos);
+                    blurred_background += sampled * weight;
                 }
-
-                float alpha = quad.color.w;
-                out_color =
-                    blurred_background * (1.0 - alpha) + vec4(quad.color.xyz * alpha, alpha);
-            } else {
-                out_color = quad.color;
             }
+
+            float alpha = quad.color.w;
+            out_color =
+                blurred_background * (1.0 - alpha) + vec4(quad.color.xyz * alpha, alpha);
+        } else {
+            out_color = quad.color;
         }
     }
 

--- a/src/default_drawables/glyph.rs
+++ b/src/default_drawables/glyph.rs
@@ -168,8 +168,16 @@ impl Drawable for GlyphState {
         vec![&self.glyph_buffer, &self.atlas]
     }
 
+    fn needs_offscreen_copy(&self) -> bool {
+        true
+    }
+
     fn start_frame(&mut self) {
         self.glyph_buffer.start_frame();
+    }
+
+    fn has_work(&self, contents: &LayerContents) -> bool {
+        !contents.glyph_runs.is_empty()
     }
 
     fn draw<'b, 'a: 'b>(

--- a/src/default_drawables/path.rs
+++ b/src/default_drawables/path.rs
@@ -61,6 +61,10 @@ impl Drawable for PathState {
         self.geometry_buffer.start_frame();
     }
 
+    fn has_work(&self, contents: &LayerContents) -> bool {
+        !contents.paths.is_empty()
+    }
+
     fn draw<'b, 'a: 'b>(
         &'a mut self,
         queue: &Queue,

--- a/src/default_drawables/quad.rs
+++ b/src/default_drawables/quad.rs
@@ -45,8 +45,18 @@ impl Drawable for QuadState {
         vec![&self.quad_buffer]
     }
 
+    fn needs_offscreen_copy(&self) -> bool {
+        true
+    }
+
     fn start_frame(&mut self) {
         self.quad_buffer.start_frame();
+    }
+
+    fn has_work(&self, contents: &LayerContents) -> bool {
+        !contents.quads.is_empty()
+            || contents.background_color.is_some()
+            || contents.background_blur_radius != 0.0
     }
 
     fn draw<'b, 'a: 'b>(

--- a/src/default_drawables/sprite.rs
+++ b/src/default_drawables/sprite.rs
@@ -79,6 +79,10 @@ impl Drawable for SpriteState {
         self.sprite_buffer.start_frame();
     }
 
+    fn has_work(&self, contents: &LayerContents) -> bool {
+        !contents.sprites.is_empty()
+    }
+
     fn draw<'b, 'a: 'b>(
         &'a mut self,
         queue: &Queue,

--- a/src/drawable.rs
+++ b/src/drawable.rs
@@ -13,7 +13,11 @@ pub trait Drawable {
 
     fn name(&self) -> &str;
     fn references(&self) -> Vec<&dyn DrawableReference>;
+    fn needs_offscreen_copy(&self) -> bool {
+        false
+    }
     fn start_frame(&mut self);
+    fn has_work(&self, contents: &LayerContents) -> bool;
 
     fn draw<'b, 'a: 'b>(
         &'a mut self,
@@ -191,8 +195,16 @@ impl DrawablePipeline {
         self.render_content_pipeline.is_some() && self.render_mask_pipeline.is_some()
     }
 
+    pub fn needs_offscreen_copy(&self) -> bool {
+        self.drawable.needs_offscreen_copy()
+    }
+
     pub fn start_frame(&mut self) {
         self.drawable.start_frame();
+    }
+
+    pub fn has_work(&self, contents: &LayerContents) -> bool {
+        self.drawable.has_work(contents)
     }
 
     pub fn draw_content<'b, 'a: 'b>(

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -433,6 +433,10 @@ impl Renderer {
         let mut content_scope = self.profiler.scope("content", encoder, &self.device);
 
         for drawable in self.drawables.iter_mut() {
+            if !drawable.has_work(contents) {
+                continue;
+            }
+
             // Either clear the offscreen texture or copy the previous layer to it
             if *first {
                 content_scope.scoped_render_pass(
@@ -453,7 +457,7 @@ impl Renderer {
                         timestamp_writes: None,
                     },
                 );
-            } else {
+            } else if drawable.needs_offscreen_copy() {
                 let mut copy_scope = content_scope.scope("Copy Frame to Offscreen", &self.device);
                 copy_scope.copy_texture_to_texture(
                     ImageCopyTexture {


### PR DESCRIPTION
marginally reduces frame copies by letting drawables specify when they need one.