### PR TITLE
Disable multisampling

### DIFF
--- a/src/drawable.rs
+++ b/src/drawable.rs
@@ -149,7 +149,7 @@ impl DrawablePipeline {
                 primitive,
                 depth_stencil: None,
                 multisample: MultisampleState {
-                    count: 4,
+                    count: 1,
                     ..Default::default()
                 },
                 multiview: None,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -24,7 +24,6 @@ pub struct Renderer {
     pub height: u32,
 
     pub offscreen_texture: ViewedTexture,
-    pub multisampled_texture: ViewedTexture,
     pub mask_texture: ViewedTexture,
     pub blank_texture: ViewedTexture,
 
@@ -64,8 +63,6 @@ impl Renderer {
         let shaders = shader_loader.load(&device);
 
         let offscreen_texture = ViewedTexture::new(&device, width, height, format, 1, "Offscreen");
-        let multisampled_texture =
-            ViewedTexture::new(&device, width, height, format, 4, "Multisampled");
         let mask_texture = ViewedTexture::new(&device, width, height, format, 1, "Mask");
         let blank_texture = ViewedTexture::new(&device, 1, 1, format, 1, "Blank");
         queue.write_texture(
@@ -167,7 +164,6 @@ impl Renderer {
             height,
 
             offscreen_texture,
-            multisampled_texture,
             mask_texture,
             blank_texture,
 
@@ -224,14 +220,6 @@ impl Renderer {
                 self.format,
                 1,
                 "Offscreen",
-            );
-            self.multisampled_texture = ViewedTexture::new(
-                &self.device,
-                new_width,
-                new_height,
-                self.format,
-                4,
-                "Multisampled",
             );
             self.mask_texture =
                 ViewedTexture::new(&self.device, new_width, new_height, self.format, 1, "Mask");
@@ -499,8 +487,8 @@ impl Renderer {
                 RenderPassDescriptor {
                     label: Some("Render Pass"),
                     color_attachments: &[Some(RenderPassColorAttachment {
-                        view: &self.multisampled_texture.view,
-                        resolve_target: Some(frame_view),
+                        view: frame_view,
+                        resolve_target: None,
                         ops: attachment_op,
                     })],
                     depth_stencil_attachment: None,


### PR DESCRIPTION
The multisampling is too heavy and not really needed.

It was also performed for all layers instead of just once on the final image, which would have made more sense. But I think we can find a better way of doing anti-aliasing without the need for doing this if we need to.

The test image of the simple path test will have to be updated, since it now lacks antialiasing.