### PR TITLE
feat: implement metal backend support for renderers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ winit = "0.30.3"
 # can write our graphics code once and run it everywhere
 [workspace.dependencies.wgpu]
 version = "22.1.0"
-features = ["vulkan-portability"]
+features = ["vulkan-portability", "metal"]
 
 [package]
 name = "vide"

--- a/src/drawable_pipeline.rs
+++ b/src/drawable_pipeline.rs
@@ -74,7 +74,7 @@ impl DrawablePipeline {
             label: Some(&format!("{} Pipeline Layout", self.name)),
             bind_group_layouts: &[&self.bind_group_layout, universal_bind_group_layout],
             push_constant_ranges: &[PushConstantRange {
-                stages: ShaderStages::all(),
+                stages: ShaderStages::VERTEX_FRAGMENT,
                 range: 0..std::mem::size_of::<ShaderConstants>() as u32,
             }],
         });
@@ -194,7 +194,11 @@ impl DrawablePipeline {
     ) {
         render_pass.set_pipeline(self.render_content_pipeline.as_ref().unwrap());
 
-        render_pass.set_push_constants(ShaderStages::all(), 0, bytemuck::cast_slice(&[constants]));
+        render_pass.set_push_constants(
+            ShaderStages::VERTEX_FRAGMENT,
+            0,
+            bytemuck::cast_slice(&[constants]),
+        );
 
         render_pass.set_bind_group(0, &self.bind_group, &[]);
         render_pass.set_bind_group(1, universal_bind_group, &[]);
@@ -215,7 +219,11 @@ impl DrawablePipeline {
     ) {
         render_pass.set_pipeline(self.render_mask_pipeline.as_ref().unwrap());
 
-        render_pass.set_push_constants(ShaderStages::all(), 0, bytemuck::cast_slice(&[constants]));
+        render_pass.set_push_constants(
+            ShaderStages::VERTEX_FRAGMENT,
+            0,
+            bytemuck::cast_slice(&[constants]),
+        );
 
         render_pass.set_bind_group(0, &self.bind_group, &[]);
         render_pass.set_bind_group(1, universal_bind_group, &[]);

--- a/src/winit_renderer.rs
+++ b/src/winit_renderer.rs
@@ -16,7 +16,7 @@ impl WinitRenderer {
     // Creating some of the wgpu types requires async code
     pub async fn new(window: Arc<Window>) -> Self {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::VULKAN,
+            backends: Self::instance_backends(),
             ..Default::default()
         });
 
@@ -56,6 +56,9 @@ impl WinitRenderer {
         let mut renderer = Renderer::new(size.width, size.height, adapter, swapchain_format).await;
         renderer.watch_shaders(shaders_reloaded);
         surface.configure(&renderer.device, &surface_config);
+
+        #[cfg(target_os = "macos")]
+        window.request_redraw();
 
         Self {
             instance,
@@ -144,5 +147,17 @@ impl WinitRenderer {
 
     fn clear_surface(&mut self) {
         self.surface = None;
+    }
+
+    pub fn instance_backends() -> Backends {
+        #[cfg(target_os = "macos")]
+        {
+            wgpu::Backends::METAL
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            wgpu::Backends::VULKAN
+        }
     }
 }


### PR DESCRIPTION
- add the `metal` backend feature to the wgpu workspace dependencies
- change the shader stages in the `drawablepipeline` implementation
- update the `wgpu` backends in the `offscreenrenderer` implementation
- add conditionals for `required_features` in `renderer` implementation
- implement platform-specific render pass logic in the `renderer` implementation
- update the `wgpu` backends in the `winitrenderer` implementation